### PR TITLE
convert empty body object to an empty body

### DIFF
--- a/lib/as.js
+++ b/lib/as.js
@@ -10,7 +10,11 @@ function asBuffer(body, options) {
   if (Buffer.isBuffer(body)) {
     ret = body;
   } else if (typeof body === 'object') {
-    ret = new Buffer(JSON.stringify(body), options.reqBodyEncoding);
+    var content = JSON.stringify(body);
+    if (content === '{}') {
+      content = '';
+    }
+    ret = new Buffer(content, options.reqBodyEncoding);
   } else if (typeof body === 'string') {
     ret = new Buffer(body, options.reqBodyEncodeing);
   }
@@ -24,6 +28,9 @@ function asBufferOrString(body) {
     ret = body;
   } else if (typeof body === 'object') {
     ret = JSON.stringify(body);
+    if (ret === '{}') {
+      ret = '';
+    }
   } else if (typeof body === 'string') {
     ret = body;
   }

--- a/test/getBody.js
+++ b/test/getBody.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var bodyParser = require('body-parser');
 var express = require('express');
 var nock = require('nock');
 var request = require('supertest');
@@ -20,6 +21,7 @@ describe('when proxy request is a GET', function () {
 
   beforeEach(function () {
     localServer = createLocalApplicationServer();
+    localServer.use(bodyParser.json());
   });
 
   afterEach(function () {
@@ -58,7 +60,7 @@ describe('when proxy request is a GET', function () {
 
     it('should deliver the get body when ' + test.name, function (done) {
       var nockedPostWithEncoding = nock('http://127.0.0.1:12345')
-        .get('/', { name: 'tobi' })
+        .get('/', test.encoding.includes('json') ? { name: 'tobi' } : '')
         .matchHeader('Content-Type', test.encoding)
         .reply(200, {
           name: 'tobi'
@@ -82,7 +84,7 @@ describe('when proxy request is a GET', function () {
 
   it('should deliver empty string get body', function (done) {
     var nockedPostWithoutBody = nock('http://127.0.0.1:12345')
-      .get('/', '')
+      .get('/', {})
       .matchHeader('Content-Type', 'application/json')
       .reply(200, {
         name: 'get with string body'
@@ -122,6 +124,33 @@ describe('when proxy request is a GET', function () {
       .expect(function (res) {
         assert(res.body.name === 'get with object body');
         nockedPostWithoutBody.done();
+      })
+      .end(done);
+  });
+
+  it('should support parseReqBody', function (done) {
+    var nockedPostWithBody = nock('http://127.0.0.1:12345')
+      .get('/', '')
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200, {
+        name: 'get with parseReqBody false'
+      });
+
+    localServer.use('/proxy', proxy('http://127.0.0.1:12345', {
+      parseReqBody: false,
+    }));
+    localServer.use(function (req, res) { res.sendStatus(200); });
+    localServer.use(function (err, req, res, next) { throw new Error(err, req, res, next); });
+
+    request(localServer)
+      .get('/proxy')
+      .send({
+        name: 'tobi'
+      })
+      .set('Content-Type', 'application/json')
+      .expect(function (res) {
+        assert(res.body.name === 'get with parseReqBody false');
+        nockedPostWithBody.done();
       })
       .end(done);
   });

--- a/test/getBody.js
+++ b/test/getBody.js
@@ -84,7 +84,7 @@ describe('when proxy request is a GET', function () {
 
   it('should deliver empty string get body', function (done) {
     var nockedPostWithoutBody = nock('http://127.0.0.1:12345')
-      .get('/', {})
+      .get('/', '')
       .matchHeader('Content-Type', 'application/json')
       .reply(200, {
         name: 'get with string body'
@@ -107,7 +107,7 @@ describe('when proxy request is a GET', function () {
 
   it('should deliver empty object get body', function (done) {
     var nockedPostWithoutBody = nock('http://127.0.0.1:12345')
-      .get('/', {})
+      .get('/', '')
       .matchHeader('Content-Type', 'application/json')
       .reply(200, {
         name: 'get with object body'


### PR DESCRIPTION
In node with request and other libraries, its conventional to send an empty body as an empty string `''`. If you use a body parser middleware with the express-http-proxy, cases which come in as an empty body, will go to the upstream service as an empty object `{}`.  

This pr demos where the empty object is introduced. 

Notes

* This would be a breaking change for some consumers of express-http-proxy
* There maybe consumers who are using an explicit `{}` and need that to be passed to upstream services as `{}`